### PR TITLE
Add python entrypoint

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -6,5 +6,6 @@ set -ex
 ./appimage/build-python.sh python2
 ./appimage/build-python.sh python3
 ./appimage/build-python.sh scipy
+./appimage/build-python.sh xonsh
 
 python3 -m tests

--- a/appimage/recipes/xonsh.sh
+++ b/appimage/recipes/xonsh.sh
@@ -1,3 +1,4 @@
 export PYTHON_VERSION="3.7.3"
 export PIP_REQUIREMENTS="xonsh prompt_toolkit gnureadline Pygments"
-export PYTHON_ENTRYPOINT='"-u" "-c" "from xonsh.main import main; main()"'  
+export PYTHON_ENTRYPOINT='"-u" "-c" "from xonsh.main import main; main()"'
+export LD_LIBRARY_PATH="AppDir/usr/python/lib/python3.7/site-packages/.libsgnureadline:${LD_LIBRARY_PATH}"

--- a/appimage/recipes/xonsh.sh
+++ b/appimage/recipes/xonsh.sh
@@ -1,0 +1,3 @@
+export PYTHON_VERSION="3.7.3"
+export PIP_REQUIREMENTS="xonsh prompt_toolkit gnureadline Pygments"
+export PYTHON_ENTRYPOINT='"-u" "-c" "from xonsh.main import main; main()"'  

--- a/appimage/recipes/xonsh.sh
+++ b/appimage/recipes/xonsh.sh
@@ -1,3 +1,0 @@
-export PYTHON_VERSION="3.7.3"
-export PIP_REQUIREMENTS="xonsh prompt_toolkit gnureadline Pygments"
-export PYTHON_ENTRYPOINT='"-u" "-c" "from xonsh.main import main; main()"'  

--- a/linuxdeploy-plugin-python.sh
+++ b/linuxdeploy-plugin-python.sh
@@ -20,7 +20,6 @@ script=$(readlink -f $0)
 exe_name="$(basename ${APPIMAGE:-$script})"
 BASEDIR="${APPDIR:-$(readlink -m $(dirname $script))}"
 
-PYTHON_ENTRYPOINT="${PYTHON_ENTRYPOINT:-}"
 
 # Parse the CLI
 show_usage () {
@@ -154,7 +153,6 @@ do
         cp "${BASEDIR}/share/python-wrapper.sh" "$python"
         sed -i "s|[{][{]PYTHON[}][}]|$python|g" "$python"
         sed -i "s|[{][{]PREFIX[}][}]|$prefix|g" "$python"
-        sed -i "s|[{][{]ENTRYPOINT[}][}]|$PYTHON_ENTRYPOINT|g" "$python"
     fi
 done
 

--- a/linuxdeploy-plugin-python.sh
+++ b/linuxdeploy-plugin-python.sh
@@ -20,6 +20,7 @@ script=$(readlink -f $0)
 exe_name="$(basename ${APPIMAGE:-$script})"
 BASEDIR="${APPDIR:-$(readlink -m $(dirname $script))}"
 
+PYTHON_ENTRYPOINT="${PYTHON_ENTRYPOINT:-}"
 
 # Parse the CLI
 show_usage () {
@@ -153,6 +154,7 @@ do
         cp "${BASEDIR}/share/python-wrapper.sh" "$python"
         sed -i "s|[{][{]PYTHON[}][}]|$python|g" "$python"
         sed -i "s|[{][{]PREFIX[}][}]|$prefix|g" "$python"
+        sed -i "s|[{][{]ENTRYPOINT[}][}]|$PYTHON_ENTRYPOINT|g" "$python"
     fi
 done
 

--- a/linuxdeploy-plugin-python.sh
+++ b/linuxdeploy-plugin-python.sh
@@ -162,7 +162,7 @@ cd "$APPDIR/${prefix}/bin"
 for exe in $(ls "${APPDIR}/${prefix}/bin"*)
 do
     if [[ -f "$exe" ]] && [[ -x "$exe" ]]; then
-        sed -i '1s|^#!.*\(python[0-9.]*\)|#!/bin/sh\n"exec" "$(dirname $(readlink -f $\{0\}))/../../bin/\1" "$0" "$@"|' "$exe"
+        sed -i '1s|^#!.*\(python[0-9.]*\).*|#!/bin/sh\n"exec" "$(dirname $(readlink -f $\{0\}))/../../bin/\1" "$0" "$@"|' "$exe"
     fi
 done
 

--- a/share/python-wrapper.sh
+++ b/share/python-wrapper.sh
@@ -34,5 +34,5 @@ fi
 # Wrap the call to Python in order to mimic a call from the source
 # executable ($ARGV0), but potentially located outside of the Python
 # install ($PYTHONHOME)
-(PYTHONHOME="${APPDIR}/${prefix}" exec -a "${executable}" "$APPDIR/${prefix}/bin/${nickname}" {{ENTRYPOINT}} "$@")
+(PYTHONHOME="${APPDIR}/${prefix}" exec -a "${executable}" "$APPDIR/${prefix}/bin/${nickname}" "$@")
 exit "$?"

--- a/share/python-wrapper.sh
+++ b/share/python-wrapper.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+SCRIPT=`realpath $0`
+SCRIPTPATH=`dirname $SCRIPT`
+APPDIR="${APPDIR:-$SCRIPTPATH/../..}"
+
 # Configure the environment
 prefix="{{PREFIX}}"
 export TCL_LIBRARY="${APPDIR}/${prefix}/share/tcltk/tcl"*

--- a/share/python-wrapper.sh
+++ b/share/python-wrapper.sh
@@ -34,5 +34,5 @@ fi
 # Wrap the call to Python in order to mimic a call from the source
 # executable ($ARGV0), but potentially located outside of the Python
 # install ($PYTHONHOME)
-(PYTHONHOME="${APPDIR}/${prefix}" exec -a "${executable}" "$APPDIR/${prefix}/bin/${nickname}" "$@")
+(PYTHONHOME="${APPDIR}/${prefix}" exec -a "${executable}" "$APPDIR/${prefix}/bin/${nickname}" {{ENTRYPOINT}} "$@")
 exit "$?"


### PR DESCRIPTION
Hi! Thank you for great work! It's really useful!

Here is the PR that allows to add python `PYTHON_ENTRYPOINT` variable with recipe example for [xonsh](https://github.com/xonsh/xonsh).

```
# python3 --help
usage: python3 [option] ... [-c cmd | -m mod | file | -] [arg] ...
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 ENTRYPOINT = python options + command + command args
```

Example for [xonsh](https://github.com/xonsh/xonsh):
```
export PYTHON_ENTRYPOINT='"-u" "-c" "from xonsh.main import main; main()"'
```