### PR TITLE
python symlink for $PATH overwriting

### DIFF
--- a/linuxdeploy-plugin-python.sh
+++ b/linuxdeploy-plugin-python.sh
@@ -228,6 +228,7 @@ patch_binary() {
 }
 
 cd "$APPDIR/${prefix}/bin"
+ln -s python3 python
 python=$(ls "python"?"."?)
 mkdir -p "${APPDIR}/usr/lib"
 cd "${APPDIR}/${prefix}/lib/${python}"


### PR DESCRIPTION
Hi! Thank you for accepting  previous PRs!

This commit adds `/usr/python/bin/python` to make ability to overwrite the host python and pip on AppImage ones by adding `bin` directory to $PATH.

For example:
```
$ ./xonsh.AppImage
xonsh# python
ImportError: No module named site 

xonsh# $PYTHONHOME
'/tmp/.mount_xonsh-*****/usr/python'

xonsh# $PATH=[ $PYTHONHOME + '/bin' ] + $PATH
xonsh# python
Python 3.7.3
>>> #success

xonsh# $PIP_TARGET='/tmp/xonsh/pip'
xonsh# import sys
xonsh# sys.path.append('/tmp/xonsh/pip') 

xonsh# pip3 install tqdm
xonsh# python
Python 3.7.3
>>> import tqdm
>>> # success
```