### PR TITLE
Fix when ARGV0 empty

### DIFF
--- a/share/python-wrapper.sh
+++ b/share/python-wrapper.sh
@@ -31,7 +31,7 @@ done
 # But don't resolve symlinks from outside!
 if [[ "${ARGV0}" =~ "/" ]]; then
     executable="$(cd $(dirname ${ARGV0}) && pwd)/$(basename ${ARGV0})"
-else
+elif [[ "${ARGV0}" != "" ]]; then
     executable=$(which "${ARGV0}")
 fi
 


### PR DESCRIPTION
Hello @niess!

When I'm using `xonsh.AppImage` on systems without FUSE I do extract and run xonsh from squash-fs folder and ARGV0 is empty. In this case I've got the error:
```
which: no  in (/usr/bin:/bin:/usr/sbin:/sbin)
```

This PR fixed this. 

Please accept and rebuild the xonsh AppImage.

Many thanks for your work around python and AppImage! The xxh/xxh is grow!