### PR TITLE
Local file issue and pip options

### DIFF
--- a/linuxdeploy-plugin-python.sh
+++ b/linuxdeploy-plugin-python.sh
@@ -111,16 +111,22 @@ cd "${PYTHON_BUILD_DIR}"
 
 
 # Install Python from sources
-source_dir=$(basename "${PYTHON_SOURCE}")
+source_file=$(basename "${PYTHON_SOURCE}")
 if [[ "${PYTHON_SOURCE}" == http* ]] || [[ "${PYTHON_SOURCE}" == ftp* ]]; then
     wget -c --no-check-certificate "${PYTHON_SOURCE}"
 else
-    cp -r "${source_dir}" "."
+    cp -r "${PYTHON_SOURCE}" "."
 fi
-if [[ "${source_dir}" == *.tgz ]] || [[ "${source_dir}" == *.tar.gz ]]; then
-    filename="${source_dir%.*}"
-    [[ -f $filename ]] || tar -xzf "${source_dir}"
-    source_dir="$filename"
+if [[ "${source_file}" == *.tgz ]] || [[ "${source_file}" == *.tar.gz ]]; then
+    if [[ "${source_file}" == *.tgz ]]; then
+        dirname="${source_file%.*}"
+    else
+        dirname="${source_file%.*.*}"
+    fi
+    [[ -f $dirname ]] || tar -xzf "${source_file}"
+    source_dir="$dirname"
+else
+    source_dir="$source_file"
 fi
 
 prefix="usr/python"
@@ -133,7 +139,7 @@ HOME="${PYTHON_BUILD_DIR}" make -j"$NPROC" DESTDIR="$APPDIR" install
 if [ ! -z "${PIP_REQUIREMENTS}" ]; then
     cd "${APPDIR}/${prefix}/bin"
     pythons=( "python"?"."? )
-    HOME="${PYTHON_BUILD_DIR}" PYTHONHOME=$(readlink -f ${PWD}/..) ./${pythons[0]} -m pip install --upgrade pip
+    HOME="${PYTHON_BUILD_DIR}" PYTHONHOME=$(readlink -f ${PWD}/..) ./${pythons[0]} -m pip install ${PIP_OPTIONS} --upgrade pip
     HOME="${PYTHON_BUILD_DIR}" PYTHONHOME=$(readlink -f ${PWD}/..) ./${pythons[0]} -m pip install ${PIP_OPTIONS} ${PIP_REQUIREMENTS}
 fi
 

--- a/linuxdeploy-plugin-python.sh
+++ b/linuxdeploy-plugin-python.sh
@@ -106,6 +106,13 @@ else
     mkdir -p "${PYTHON_BUILD_DIR}"
 fi
 
+# check if the given sources are a local file or directory; if yes,
+# "save" the full path. It might've been given relative to the current
+# directory.
+if [ -e "${PYTHON_SOURCE}" ]; then
+    PYTHON_SOURCE=$( readlink -f "${PYTHON_SOURCE}" )
+fi
+
 cd "${PYTHON_BUILD_DIR}"
 
 


### PR DESCRIPTION
If you reference a local source file or directory, the script tries to "find" it in the temporary build directory, because it stripped the path. Also it won't work, if the user gave a relative path to the file. Therefore we convert the source path to an absolute one (if it's actually a local path) and handle it correctly.

Also added the PIP_OPTIONS to the pip upgrade call; otherwise the upgrade might fail if the user needs a special configuration to reach the package index (e.g. coproprate proxy... my nemesis... 😆).