### PR TITLE
Projects that use linuxdeploy-plugin-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ the [wiki][WIKI_USERS] for more detailed usage.
 
 [WIKI_DEVS]: ../../wiki/Developers
 [WIKI_USERS]: ../../wiki/Users
+
+## Projects that use linuxdeploy-plugin-python
+* [xxh](https://github.com/xxh/xxh) - bring your favorite shell wherever you go through the ssh 


### PR DESCRIPTION
Hi! I suggest to add the section "Projects that use linuxdeploy-plugin-python" to show plugin use cases.